### PR TITLE
Make work with Julia 1.5

### DIFF
--- a/src/Polyopt.jl
+++ b/src/Polyopt.jl
@@ -4,12 +4,12 @@ export solve_mosek, monomials
 export MomentProb, momentprob, momentprob_chordal, momentprob_chordalembedding 
 export BSOSProb, bsosprob_chordal
 
-import Base.^, Base.start, Base.next, Base.done, Base.sub, Base.length
+import Base.^, Base.length, Base.iterate, Base.eltype
 
 include("polynomial.jl")
 include("cliques.jl")
 
-immutable MomentProb{T<:Number}
+struct MomentProb{T<:Number}
     order :: Int
     basis :: Vector{Poly{Int}}
     obj   :: AbstractArray{T}
@@ -17,7 +17,7 @@ immutable MomentProb{T<:Number}
     eq    :: Array{Any,1}
 end
 
-immutable BSOSProb{T<:Number}
+struct BSOSProb{T<:Number}
     degree :: Int
     order  :: Int
     obj    :: AbstractArray{T}
@@ -31,7 +31,7 @@ include("solver_mosek.jl")
 include("latex.jl")
 
 
-immutable MonomialPowers
+struct MonomialPowers
     n :: Int
     d :: Int
 end
@@ -40,9 +40,12 @@ monomialpowers(n, d) = MonomialPowers(n, d)
 start(m::MonomialPowers) = zeros(Int, m.n)
 done(m::MonomialPowers, state::Vector{Int}) = (state[1] == m.d+1)
 length(m::MonomialPowers) = binomial(m.n + m.d, m.d)
+eltype(m::MonomialPowers) = Vector{Int}
 
-function next(m::MonomialPowers, powers::Vector{Int})
+function iterate(m::MonomialPowers, powers::Vector{Int}=zeros(Int, m.n))
 
+    if powers[1] > m.d return nothing end
+    
     # find index of element to increment
     k = m.n
     while (k>1)
@@ -53,22 +56,22 @@ function next(m::MonomialPowers, powers::Vector{Int})
     end     
 
     state = copy(powers)    
-    state[k+1:end] = 0                        
+    state[k+1:end] .= 0                        
     state[k] += 1
     
     powers, state
 end
 
-function monomials{T<:Number}(deg::Int, vars::Array{Poly{T},1})
+function monomials(deg::Int, vars::Array{Poly{T},1}) where {T<:Number}
     n = length(vars)
-    I = [ findfirst(vi.alpha) for vi=vars ]
+    I = [ findfirst(x -> x != 0, vi.alpha) for vi=vars ]
     
-    v = Array(Poly{Int}, binomial(n+deg, deg))
+    v = Array{Poly{Int}}(undef, binomial(n+deg, deg))
     alpha = zeros(Int, 1, vars[1].n)
-    for (i,a)=enumerate(monomialpowers(n, deg))            
+    for (i,a)=enumerate(monomialpowers(n, deg))  
         alpha[I] = a
-        v[i] = Poly(vars[1].syms, copy(alpha), [1])
-        alpha[I] = 0
+        v[i] = Poly{Int}(vars[1].syms, copy(alpha), [1])
+        alpha[I] .= 0
     end
     v        
 end
@@ -83,13 +86,13 @@ function moment(order::Int, syms::Symbols, I::Array{Int})
     v*v'
 end
 
-function moment{T<:Number}(order::Int, syms::Symbols, p::Poly{T})
-    v = monomials(order - (p.deg+1) >> 1, variables(syms))
+function moment(order::Int, syms::Symbols, p::Poly{T}) where {T<:Number}
+    v = monomials(order - (p.deg+1)>>1, variables(syms))
     p*v*v'
 end
 
-function moment{T<:Number}(order::Int, syms::Symbols, p::Poly{T}, I::Array{Int})
-    v = monomials(order - (p.deg+1) >> 1, variables(syms)[I])
+function moment(order::Int, syms::Symbols, p::Poly{T}, I::Array{Int}) where {T<:Number}
+    v = monomials(order - (p.deg+1)>>1, variables(syms)[I])
     p*v*v'
 end
 
@@ -118,9 +121,13 @@ basis_index(p::Poly, degree::Int) = basis_index(vec(p.alpha), degree)
 
 linear_index(p::Poly, d::Int) = Int[ basis_index(vec(p.alpha[i,:]), d) for i=1:p.m ]
 
-vectorize{T<:Number}(p::Polyopt.Poly{T}, d::Int) = sparsevec(linear_index(p, d), p.c, binomial(p.n+d,d))
+vectorize(p::Polyopt.Poly{T}, d::Int) where {T<:Number} = sparsevec(linear_index(p, d), p.c, binomial(p.n+d,d))
 
-function vectorize{T<:Number}(A::AbstractArray{Poly{T}}, d::Int)
+function find_replacement(v)
+    [x for (x,y) in filter((y->(y[2] != 0)), Tuple(enumerate(v)))]
+end
+
+function vectorize(A::AbstractArray{Poly{T}}, d::Int) where {T<:Number}
     dims = length(size(A))
     if dims==1
         m, n = length(A), 1
@@ -144,20 +151,20 @@ function vectorize{T<:Number}(A::AbstractArray{Poly{T}}, d::Int)
     sparse(subi, subj, val, m*n, binomial(A[1].n+d,d))
 end
 
-function momentprob{S,T,U}(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{U},1})
+function momentprob(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{U},1}) where {S<:Number,T<:Number,U<:Number}
 
     v = monomials(2*order, variables(obj.syms))
     obj.deg <= 2*order || error("obj has degree higher than 2*order")
 
     p = vectorize(obj, 2*order)
-    mom = Array(Any, length(pineq)+1)
+    mom = Array{Any}(undef, length(pineq)+1)
     mom[1] = vectorize(moment(order, obj.syms), 2*order)
     for k=1:length(pineq)
        pineq[k].deg <= 2*order || error("pineq[$(k)] has degree higher than 2*order")
        mom[k+1] = vectorize(moment(order, pineq[k].syms, pineq[k]), 2*order)
     end
 
-    momeq = Array(Any, length(peq))
+    momeq = Array{Any}(undef, length(peq))
     for k=1:length(peq)
         peq[k].deg <= 2*order || error("peq[$(k)] has degree higher than 2*order")
         momeq[k] = vectorize(moment(order, peq[k].syms, peq[k]), 2*order)
@@ -166,14 +173,14 @@ function momentprob{S,T,U}(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}, pe
     MomentProb(order, v, p, mom, momeq)
 end
 
-momentprob{S}(order::Int, obj::Poly{S}) =
+momentprob(order::Int, obj::Poly{S}) where {S<:Number} =
     momentprob(order, obj, Poly{Int}[], Poly{Int}[])
 
-momentprob{S,T}(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}) =
+momentprob(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}) where {S<:Number,T<:Number}  =
     momentprob(order, obj, pineq, Poly{Int}[])
 
-function momentprob_chordal{S,T,U}(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S},
-                                   pineq::Array{Poly{T},1}, peq::Array{Poly{U},1})
+function momentprob_chordal(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S},
+                                   pineq::Array{Poly{T},1}, peq::Array{Poly{U},1}) where {S<:Number,T<:Number,U<:Number}
 
     v = monomials(2*order, variables(obj.syms))
     obj.deg <= 2*order || error("obj has degree higher than 2*order")
@@ -186,7 +193,7 @@ function momentprob_chordal{S,T,U}(order::Int, cliques::Array{Array{Int,1},1}, o
     
     for k=1:length(pineq)
         pineq[k].deg <= 2*order || error("pineq[$(k)] has degree higher than 2*order")
-        for j=clique_index(cliques, find(sum(pineq[k].alpha,1)), obj.n)
+        for j=clique_index(cliques, find_replacement(sum(pineq[k].alpha,dims=1)), obj.n)
             push!(mom,vectorize(moment(order, pineq[k].syms, pineq[k], cliques[j]), 2*order))
         end
     end
@@ -194,7 +201,7 @@ function momentprob_chordal{S,T,U}(order::Int, cliques::Array{Array{Int,1},1}, o
     momeq = []
     for k=1:length(peq)
         peq[k].deg <= 2*order || error("peq[$(k)] has degree higher than 2*order")
-        for j=clique_index(cliques, find(sum(peq[k].alpha,1)), obj.n)
+        for j=clique_index(cliques, find_replacement(sum(peq[k].alpha,dims=1)), obj.n)
             push!(momeq, vectorize(moment(order, peq[k].syms, peq[k], cliques[j]), 2*order))
         end
     end
@@ -202,53 +209,53 @@ function momentprob_chordal{S,T,U}(order::Int, cliques::Array{Array{Int,1},1}, o
     MomentProb(order, v,  p, mom, momeq)
 end
 
-momentprob_chordal{S,T}(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S}, pineq::Array{Poly{T},1}) = 
+momentprob_chordal(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S}, pineq::Array{Poly{T},1}) where {S<:Number,T<:Number} = 
     momentprob_chordal(order, cliques, obj, pineq, Poly{Int}[])
 
-momentprob_chordal{S}(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S}) = 
+momentprob_chordal(order::Int, cliques::Array{Array{Int,1},1}, obj::Poly{S}) where {S<:Number} = 
     momentprob_chordal(order, cliques, obj, Poly{Int}[], Poly{Int}[])
                                   
-function correlative_sparsity{S,T}(obj::Poly{S}, p::Array{Poly{T},1})
-    A = eye(Int,obj.n,obj.n)
+function correlative_sparsity(obj::Poly{S}, p::Array{Poly{T},1}) where {S<:Number,T<:Number}
+    A = Matrix{Int}(LinearAlgebra.I,obj.n,obj.n)
 
     for k=1:obj.m
-        I = find(obj.alpha[k,:])
-        A[I,I] = 1
+        I = find_replacement(obj.alpha[k,:])
+        A[I,I] .= 1
     end
 
     for j=1:length(p)
-        I = find(sum(p[j].alpha,1))
-        A[I,I] = 1
+        I = find_replacement(sum(p[j].alpha,dims=1))
+        A[I,I] .= 1
     end
     sparse(A)
 end
 
-function momentprob_chordalembedding{S,T,U}(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{U},1})
+function momentprob_chordalembedding(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{U},1}) where {S<:Number,T<:Number,U<:Number}
     C = correlative_sparsity(obj, [pineq; peq])
     cliques = chordal_embedding(C)
     momentprob_chordal(order, cliques, obj, pineq, peq)
 end
 
-momentprob_chordalembedding{S,T}(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}) =
+momentprob_chordalembedding(order::Int, obj::Poly{S}, pineq::Array{Poly{T},1}) where {S<:Number,T<:Number} =
     momentprob_chordalembedding(order, obj, pineq, Poly{Int}[])
 
-momentprob_chordalembedding{S}(order::Int, obj::Poly{S}) =
+momentprob_chordalembedding(order::Int, obj::Poly{S}) where {S<:Number} =
     momentprob_chordalembedding(order, obj, Poly{Int}[], Poly{Int}[])
 
-function symbol_restrict{T<:Number}(p::Poly{T}, syms::Symbols, I::Array{Int,1})
+function symbol_restrict(p::Poly{T}, syms::Symbols, I::Array{Int,1}) where {T<:Number}
 
     if p.n == 0
         p
     else
         mask = ones(Int, p.n)
-        mask[I] = 0    
-        J = find(p.alpha * mask .== 0)
+        mask[I] .= 0    
+        J = find_replacement(p.alpha * mask .== 0)
         Poly{T}(syms, p.alpha[J,I], p.c[J])
     end
 end
 
-function bsosprob_chordal{S,T,V}(degree::Int, order::Int, cliques::Array{Array{Int,1}}, 
-                                    obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{V},1})
+function bsosprob_chordal(degree::Int, order::Int, cliques::Array{Array{Int,1}}, 
+                                    obj::Poly{S}, pineq::Array{Poly{T},1}, peq::Array{Poly{V},1})where {S<:Number,T<:Number,V<:Number}
 
     n = obj.n
     
@@ -265,7 +272,7 @@ function bsosprob_chordal{S,T,V}(degree::Int, order::Int, cliques::Array{Array{I
     end
 
     for (i, gi) in enumerate(pineq)
-        for j=clique_index(cliques, find(sum(gi.alpha,1)), n)
+        for j=clique_index(cliques, find_replacement(sum(gi.alpha,dims=1)), n)
             append!(Ji[j], i)
         end
     end
@@ -276,7 +283,7 @@ function bsosprob_chordal{S,T,V}(degree::Int, order::Int, cliques::Array{Array{I
     end
 
     for (i, hi) in enumerate(peq)
-        for j=clique_index(cliques, find(sum(hi.alpha,1)), n)
+        for j=clique_index(cliques, find_replacement(sum(hi.alpha,dims=1)), n)
             append!(Je[j], i)
         end
     end
@@ -339,7 +346,7 @@ function bsosprob_chordal{S,T,V}(degree::Int, order::Int, cliques::Array{Array{I
         push!(Al, sparse(ai, aj, av, len_ab_d, binomial(length(c)+dmax,dmax)))  
         push!(lb, lbj)
            
-        k = Array(Int, binomial(length(c)+dmax, dmax))
+        k = Array{Int,1}(undef, binomial(length(c)+dmax, dmax))
         alpha = zeros(Int, n)
         for (i,a)=enumerate(monomialpowers(length(c), dmax))            
             alpha[c] = a
@@ -354,7 +361,7 @@ function bsosprob_chordal{S,T,V}(degree::Int, order::Int, cliques::Array{Array{I
     BSOSProb(degree, order, f, Al, El, As, lb)
 end
 
-bsosprob_chordal{S,T}(degree::Int, order::Int, cliques::Array{Array{Int,1}}, obj::Poly{S}, pineq::Array{Poly{T},1}) =
+bsosprob_chordal(degree::Int, order::Int, cliques::Array{Array{Int,1}}, obj::Poly{S}, pineq::Array{Poly{T},1}) where {S<:Number,T<:Number} =
     bsosprob_chordal(degree, order, cliques, obj, pineq, Poly{Int}[])
 
 end

--- a/src/cliques.jl
+++ b/src/cliques.jl
@@ -40,11 +40,11 @@ function pothen_sun(par::Vector{T}, post::Vector{T}, colcount::Vector{T}) where 
     ns, flag
 end
 
-function round_array(T, A)
+function round_array(T, A::SparseMatrixCSC{Tv,Ti}) where {Tv<:Number,Ti<:Int}
     if T <: Integer
-        map(x->Base.round(T,x),A)
+        convert(SparseMatrixCSC{T,Ti},map(x->Base.round(T,x),A))
     else 
-        map(x->Base.round(x),A)
+        convert(SparseMatrixCSC{T,Ti},map(x->Base.round(x),A))
     end
 end
 
@@ -54,7 +54,7 @@ function chordal_embedding(A::SparseMatrixCSC{Tv,Ti}, Perm::Vector{Ti}) where {T
     
     F = cholesky(round_array(Float64,A), shift=n, perm=Perm)    
     s = F.p
-    p = round_array(Int64,[ s[i] for i=1:length(s)])
+    p = [ round(Int64,s[i]) for i=1:length(s)]
 
     par, post, colcount = chm_analyze_ordering(S, s.ordering, p)
     ns, flag = pothen_sun(par+1, post+1, colcount)

--- a/src/cliques.jl
+++ b/src/cliques.jl
@@ -1,14 +1,17 @@
-using Base.SparseArrays.CHOLMOD
+using SparseArrays
+using SuiteSparse.CHOLMOD
+using LinearAlgebra
 
-function chm_analyze_ordering{Tv<:CHOLMOD.VTypes}(A::CHOLMOD.Sparse{Tv}, ordering::Cint, Perm::Vector{Int})
-    s = unsafe_load(A.p)
-    Parent   = Array(Int,s.nrow)
-    Post     = Array(Int,s.nrow)
-    ColCount = Array(Int,s.nrow)
-    First    = Array(Int,s.nrow)
-    Level    = Array(Int,s.nrow)
 
-    ccall((@CHOLMOD.cholmod_name("analyze_ordering",Int),:libcholmod), Cint,
+function find_replacement(v)
+    [x for (x,y) in filter((y->(y[2] != 0)), Tuple(enumerate(v)))]
+end
+
+function chm_analyze_ordering(A::CHOLMOD.Sparse{Tv}, ordering::Cint, Perm::Vector{Int}) where {Tv<:CHOLMOD.VTypes}
+    s = A.p
+    Parent   = Array{Int,1}(undef,size(s)[1])
+
+    ccall((@CHOLMOD.cholmod_name(("analyze_ordering",Int)),:libcholmod), Cint,
           (Ptr{CHOLMOD.C_Sparse{Tv}}, Cint, Ptr{Int}, Ptr{Int}, Csize_t,
            Ptr{Int}, Ptr{Int}, Ptr{Int},
            Ptr{Int}, Ptr{Int}, Ptr{UInt8}),
@@ -16,7 +19,7 @@ function chm_analyze_ordering{Tv<:CHOLMOD.VTypes}(A::CHOLMOD.Sparse{Tv}, orderin
     Parent, Post, ColCount
 end
 
-function pothen_sun{T<:Integer}(par::Vector{T}, post::Vector{T}, colcount::Vector{T})
+function pothen_sun(par::Vector{T}, post::Vector{T}, colcount::Vector{T}) where {T<:Integer}
     n = length(par)
     flag = -ones(T,n)
     ns = n
@@ -37,24 +40,32 @@ function pothen_sun{T<:Integer}(par::Vector{T}, post::Vector{T}, colcount::Vecto
     ns, flag
 end
 
-function chordal_embedding{Tv<:Number,Ti<:Int}(A::SparseMatrixCSC{Tv,Ti}, Perm::Vector{Ti})
+function round_array(T, A)
+    if T <: Integer
+        map(x->Base.round(T,x),A)
+    else 
+        map(x->Base.round(x),A)
+    end
+end
+
+function chordal_embedding(A::SparseMatrixCSC{Tv,Ti}, Perm::Vector{Ti}) where {Tv<:Number,Ti<:Int}
     m, n = size(A)
-    S = CHOLMOD.Sparse(round(Float64,A))
+    S = CHOLMOD.Sparse(round_array(Float64,A))
     
-    F = cholfact(round(Float64,A), shift=n, perm=Perm)    
-    s = unsafe_load(F.p)
-    p = round(Int64,[ unsafe_load(s.Perm, i) for i=1:s.n])
+    F = cholesky(round_array(Float64,A), shift=n, perm=Perm)    
+    s = F.p
+    p = round_array(Int64,[ s[i] for i=1:length(s)])
 
     par, post, colcount = chm_analyze_ordering(S, s.ordering, p)
     ns, flag = pothen_sun(par+1, post+1, colcount)
 
     # extract cliques
     L = sparse(CHOLMOD.Sparse(F))
-    Array{Int,1}[ sort(1+p[L.rowval[L.colptr[i]:L.colptr[i+1]-1]]) for i = find(flag .< 0) ]
+    Array{Int,1}[ sort(1+p[L.rowval[L.colptr[i]:L.colptr[i+1]-1]]) for i = find_replacement(flag .< 0) ]
 end
 
 # If no permutation is specified, use the CHOLMOD ordering
-chordal_embedding{Tv<:Number,Ti<:Int}(A::SparseMatrixCSC{Tv,Ti}) = chordal_embedding(A, Array(Int,0))
+chordal_embedding(A::SparseMatrixCSC{Tv,Ti}) where {Tv<:Number,Ti<:Int} = chordal_embedding(A, Array{Int,1}(undef,0))
 
 function clique_index(I::Array{Array{Int,1},1}, S::Array{Int,1}, n::Int)
 
@@ -63,11 +74,11 @@ function clique_index(I::Array{Array{Int,1},1}, S::Array{Int,1}, n::Int)
     s = sparsevec(S, 1, n)    
     for k=1:length(I)
         if length(S) <= length(I[k]) 
-            mask[I[k]] = 1    
+            mask[I[k]] .= 1    
             if dot(mask, s) == length(S)
                 push!(J, k)
             end
-            mask[I[k]] = 0
+            mask[I[k]] .= 0
         end
     end
     J

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -1,4 +1,6 @@
-texstring{T<:Number}(a::T) = string(a)
+using Printf
+
+texstring(a::T) where {T<:Number} = string(a)
 texstring(a::Float64) = string(@sprintf("%1.2f",a))
 texstring(a::Rational) = ( a.den == one(a) ? string(a.num) : string("\\frac{", a.num, "}{", a.den, "}") )
 
@@ -57,7 +59,7 @@ function latex(p::Poly, imap::Dict{Array{Int,2},Int}, texsymbols::Array{String,1
     s
 end
 
-function latex{T}(M::Array{Poly{T}}, imap::Dict{Array{Int,2},Int}, texsymbols::Array{String,1}, matrixlimit = 10)
+function latex(M::Array{Poly{T}}, imap::Dict{Array{Int,2},Int}, texsymbols::Array{String,1}, matrixlimit = 10) where {T<:Number}
     n = size(M,1)
     s = "\\left[\n\\begin{array}{*{$(min(matrixlimit,n))}c}\n"
     if matrixlimit < n
@@ -113,7 +115,7 @@ end
 function latex_dual(prob::MomentProb, vectorizednames::Bool, matrixlimit::Int)
 
     imap = Polyopt.indexmap(prob.basis)
-    syms = Array(String, length(imap))
+    syms = Array{String,1}(undef, length(imap))
 
     if vectorizednames == true
         for (key,k) = imap
@@ -135,8 +137,8 @@ function latex_probstats(prob::MomentProb)
     avgblksize  = int(mean(sdpblksize))
 
     eqsize      = [ int(sqrt(size(m,1))) for m=prob.eq ]
-    numfree     = sum(Int[ n*(n+1) >> 1 for n=eqsize ])
-    numvar      = sum([ n*(n+1) >> 1 for n=sdpblksize ]) + numfree
+    numfree     = sum(Int[ n*(n+1)/2 for n=eqsize ])
+    numvar      = sum([ n*(n+1)/2 for n=sdpblksize ]) + numfree
     numcon      = length(prob.basis)-1
 
     maxrhs  = maximum(prob.obj)

--- a/src/polynomial.jl
+++ b/src/polynomial.jl
@@ -1,12 +1,17 @@
-import Base: show, *, -, +, isless, ==, convert, conj, truncate, zero, one, promote_rule, A_mul_B!, dot, transpose
+
+
+import Base: show, *, -, +, isless, ==, convert, conj, truncate, zero, one, promote_rule, transpose, adjoint, sub, round
+import LinearAlgebra: dot, mul!
+
+using SparseArrays
 
 export variables
 
-immutable Symbols{T<:AbstractString}
+struct Symbols{T<:AbstractString}
     names :: Array{T,1}
 end
 
-immutable Poly{T<:Number}
+struct Poly{T<:Number}
     n        :: Int             # number of symbols in monomials
     m        :: Int             # number of monomials
     syms     :: Symbols
@@ -14,39 +19,39 @@ immutable Poly{T<:Number}
     alpha    :: Array{Int, 2}   # powers of symbols for all monomials
     deg      :: Int
 
-    function Poly(syms::Symbols, alpha::Array{Int,2}, c::Array{T,1})
+    function Poly{T}(syms::Symbols, alpha::Array{Int,2}, c::Array{T,1}) where {T<:Number}
         m, n = size(alpha)
         if length(c) != m error("incompatible dimensions") end
         
-        deg = size(alpha, 1) > 0 ? maximum(sum(alpha,2)) : 0        
-        new(n, m, syms, c, alpha, deg)
+        deg = size(alpha, 1) > 0 ? maximum(sum(alpha,dims=2)) : 0        
+        new{T}(n, m, syms, c, alpha, deg)
     end
 
     # we allow a constant polynomial without a proper symbol basis
-    Poly(c::T) = new(0, 1, Symbols([""]), [c], Array(T, 1, 0), 0)
+    Poly{T}(c::T) where {T<:Number} = new{T}(0, 1, Symbols([""]), [c], Array{T,2}(undef, 1,0), 0)
 end
 
-Poly{T<:Number}(syms::Symbols, alpha::Array{Int,2}, c::Array{T,1}) = Poly{T}(syms, alpha, c)
-Poly{T<:Number}(c::T) = Poly{T}(c)
+#Poly{T}(syms::Symbols, alpha::Array{Int,2}, c::Array{T,1}) where {T<:Number} = Poly{T}(syms, alpha, c)
+#Poly{T}(c::T) where {T<:Number} = Poly{T}(c)
 
-convert{S,T}(::Type{Poly{S}}, p::Poly{T}) = Poly(p.syms, p.alpha, convert(Array{S}, p.c))
-convert{S,T}(::Type{Poly{S}}, c::T) = Poly{promote_type(S,T)}(p.syms, p.alpha, convert(promote_type(S,T), c))
-convert{S<:Number,T<:Number}(::Type{Polyopt.Poly{S}}, v::T) = convert(Polyopt.Poly{S},convert(S,v))
+convert(::Type{Poly{S}}, p::Poly{T}) where {S<:Number,T<:Number} = Poly{S}(p.syms, p.alpha, convert(Array{S}, p.c))
+convert(::Type{Poly{S}}, c::T) where {S<:Number,T<:Number} = Poly{promote_type(S,T)}(p.syms, p.alpha, convert(promote_type(S,T), c))
+convert(::Type{Polyopt.Poly{S}}, v::T) where {S<:Number,T<:Number} = convert(Polyopt.Poly{S},convert(S,v))
 
-zero{T<:Number}(::Type{Poly{T}}) = Poly(zero(T))
-zero{T<:Number}(::Poly{T}) = Poly(zero(T))
-one{T<:Number}(::Type{Poly{T}}) = Poly(one(T))
-one{T<:Number}(::Poly{T}) = Poly(one(T))
+zero(::Type{Poly{T}}) where {T<:Number} = Poly{T}(zero(T))
+zero(::Poly{T}) where {T<:Number} = Poly{T}(zero(T))
+one(::Type{Poly{T}}) where {T<:Number} = Poly{T}(one(T))
+one(::Poly{T}) where {T<:Number} = Poly{T}(one(T))
 
-promote_rule{S<:Number,T<:Number}(::Type{S}, ::Type{Poly{T}}) = Poly{promote_type(S,T)}
-promote_rule{S<:Number,T<:Number}(::Type{Poly{S}}, ::Type{Poly{T}}) = Poly{promote_type(S,T)}
+promote_rule(::Type{S}, ::Type{Poly{T}}) where {S<:Number,T<:Number} = Poly{promote_type(S,T)}
+promote_rule(::Type{Poly{S}}, ::Type{Poly{T}}) where {S<:Number,T<:Number} = Poly{promote_type(S,T)}
 promote_rule(::Type{Rational}, ::Type{Int}) = Rational
 
 dot(a::Poly, b::Poly) = a*b
 dot(a::Number, b::Poly) = a*b
 dot(a::Poly, b::Number) = a*b
 
-function show{T}(io::IO, p::Poly{T})
+function show(io::IO, p::Poly{T}) where {T<:Number}
     if p.m == 0 print(io, zero(T)) end
     for i=1:p.m
         if i==1
@@ -75,63 +80,63 @@ function show{T}(io::IO, p::Poly{T})
     end
 end
 
--{T<:Number}(p::Poly{T}) = Poly{T}(p.syms, p.alpha, -p.c)
-+{S<:Number,T<:Number}(p::Poly{S}, a::T) = p + Poly{T}(p.syms, zeros(Int64, 1, p.n), T[a])
-+{S<:Number,T<:Number}(a::S, p::Poly{T}) = Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a]) + p
--{S<:Number,T<:Number}(p::Poly{T}, a::S) = p - Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a])
--{S<:Number,T<:Number}(a::S, p::Poly{T}) = Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a]) - p
+-(p::Poly{T}) where {T<:Number}= Poly{T}(p.syms, p.alpha, -p.c)
++(p::Poly{S}, a::T) where {S<:Number,T<:Number} = p + Poly{T}(p.syms, zeros(Int64, 1, p.n), T[a])
++(a::S, p::Poly{T}) where {S<:Number,T<:Number} = Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a]) + p
+-(p::Poly{T}, a::S) where {S<:Number,T<:Number} = p - Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a])
+-(a::S, p::Poly{T}) where {S<:Number,T<:Number} = Poly{S}(p.syms, zeros(Int64, 1, p.n), S[a]) - p
 
-*{S<:Number,T<:Number}(p::Poly{S}, a::T) = simplify(Poly{promote_type(S,T)}(p.syms, p.alpha, p.c*a))
-*{S<:Number,T<:Number}(a::S, p::Poly{T}) = *(p::Poly{T}, a::S)
+*(p::Poly{S}, a::T) where {S<:Number,T<:Number} = simplify(Poly{promote_type(S,T)}(p.syms, p.alpha, p.c*a))
+*(a::S, p::Poly{T}) where {S<:Number,T<:Number} = *(p::Poly{T}, a::S)
 
-function add{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T})
+function add(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number}
     U = Array{promote_type(S, T),1}
     p1, p2 = promote_poly(p1, p2)
     Poly{promote_type(S,T)}(p1.syms, vcat(p1.alpha, p2.alpha), vcat(convert(U,p1.c), convert(U,p2.c)))
 end
 
-function sub{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T})
+function sub(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number}
     U = Array{promote_type(S, T),1}
     p1, p2 = promote_poly(p1, p2)
     Poly{promote_type(S,T)}(p1.syms, vcat(p1.alpha, p2.alpha), vcat(convert(U,p1.c), -convert(U,p2.c)))
 end
 
-+{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T}) = simplify( add(p1, p2) )
--{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T}) = simplify( sub(p1, p2) )
++(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number} = simplify( add(p1, p2) )
+-(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number} = simplify( sub(p1, p2) )
 
-function *{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T})
+function *(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number}
     p1, p2 = promote_poly(p1, p2)
     if p2.m == 1
-        Poly(p1.syms, p1.alpha .+ p2.alpha, p1.c*p2.c[1])
+        Poly{promote_type(S,T)}(p1.syms, p1.alpha .+ p2.alpha, p1.c*p2.c[1])
     elseif p1.m == 1
-        Poly(p1.syms, p2.alpha .+ p1.alpha, p2.c*p1.c[1])
+        Poly{promote_type(S,T)}(p1.syms, p2.alpha .+ p1.alpha, p2.c*p1.c[1])
     else
         if p1.m < p2.m
             #r = Poly(p1.syms, p2.alpha .+ p1.alpha[1:1,:], p2.c*p1.c[1])
-            r = Poly(p1.syms, p2.alpha .+ view(p1.alpha,1:1,:), p2.c*p1.c[1])
+            r = Poly{promote_type(S,T)}(p1.syms, p2.alpha .+ view(p1.alpha,1:1,:), p2.c*p1.c[1])
             for k=2:p1.m
                 #r = add(r, Poly(p1.syms, p2.alpha .+ p1.alpha[k:k,:], p2.c*p1.c[k]))
-                r = add(r, Poly(p1.syms, p2.alpha .+ view(p1.alpha,k:k,:), p2.c*p1.c[k]))
+                r = add(r, Poly{promote_type(S,T)}(p1.syms, p2.alpha .+ view(p1.alpha,k:k,:), p2.c*p1.c[k]))
             end
         else
             #r = Poly(p1.syms, p1.alpha .+ p2.alpha[1:1,:], p1.c*p2.c[1])
-            r = Poly(p1.syms, p1.alpha .+ view(p2.alpha,1:1,:), p1.c*p2.c[1])
+            r = Poly{promote_type(S,T)}(p1.syms, p1.alpha .+ view(p2.alpha,1:1,:), p1.c*p2.c[1])
             for k=2:p2.m
                 #r = add(r, Poly(p1.syms, p1.alpha .+ p2.alpha[k:k,:], p1.c*p2.c[k]))
-                r = add(r, Poly(p1.syms, p1.alpha .+ view(p2.alpha,k:k,:), p1.c*p2.c[k]))
+                r = add(r, Poly{promote_type(S,T)}(p1.syms, p1.alpha .+ view(p2.alpha,k:k,:), p1.c*p2.c[k]))
             end
         end
         simplify(r)
     end
 end
 
-function ^{T<:Number}(p::Poly{T}, a::Int)
+function ^(p::Poly{T}, a::Int) where {T<:Number}
     if a<0 error("power must be nonnegative") end
     if a==0 return Poly{T}(p.syms, zeros(Int, 1, p.n), [one(T)]) end
     if a==1 return Poly{T}(p.syms, p.alpha, p.c) end
     if p.m == 1 return Poly{T}(p.syms, p.alpha*a, p.c.^a) end
 
-    powers = Array(Poly{T}, Int(1+ceil(log2(a))))
+    powers = Array{Poly{T},1}(undef, Int(1+ceil(log2(a))))
     
     @inbounds begin    
     powers[1] = p
@@ -155,27 +160,27 @@ function ^{T<:Number}(p::Poly{T}, a::Int)
     r
 end
 
-typealias MatOrVec{T} Union{Array{T,1},Array{T,2}}
+const MatOrVec{T} = Union{Array{T,1},Array{T,2}}
 
-*{T<:Number,S<:Number}(a::T, v::MatOrVec{Poly{S}}) = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
-*{T<:Number,S<:Number}(v::MatOrVec{Poly{T}}, a::S) = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
-*{T<:Number,S<:Number}(a::Poly{T}, v::MatOrVec{Poly{S}}) = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
-*{T<:Number,S<:Number}(v::MatOrVec{Poly{S}}, a::Poly{T}) = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
+*(a::T, v::MatOrVec{Poly{S}}) where {S<:Number,T<:Number} = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
+*(v::MatOrVec{Poly{T}}, a::S) where {S<:Number,T<:Number} = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
+*(a::Poly{T}, v::MatOrVec{Poly{S}}) where {S<:Number,T<:Number} = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
+*(v::MatOrVec{Poly{S}}, a::Poly{T}) where {S<:Number,T<:Number} = reshape(Poly{promote_type(T,S)}[ a*vi for vi=v ], size(v))
 
-function =={S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T}) 
+function ==(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number} 
     r = p1-p2
     r.m == 0 || r.n == 0
 end
 
-=={S<:Number,T<:Number}(p::Poly{S}, c::T) = p == Poly(c) 
-=={S<:Number,T<:Number}(c::S, p::Poly{T}) = p == Poly(c) 
+==(p::Poly{S}, c::T) where {S<:Number,T<:Number} = p == Poly{T}(c) 
+==(c::S, p::Poly{T}) where {S<:Number,T<:Number} = p == Poly{S}(c) 
 
-conj{T<:Number}(p::Poly{T}) = Poly{T}(p.syms, p.alpha, conj(p.c))
-convert{T<:Number}(::Type{Poly{T}}, a::T) = Poly{T}(convert(T,a))
-#isconst{T<:Number}(p::Poly{T}) = (p.m == 0 || p.n == 0)
-isconst{T<:Number}(p::Poly{T}) = p.n == 0
+conj(p::Poly{T}) where {T<:Number} = Poly{T}(p.syms, p.alpha, conj(p.c))
+convert(::Type{Poly{T}}, a::T) where {T<:Number} = Poly{T}(convert(T,a))
+#isconst(p::Poly{T}) where {T<:Number} = (p.m == 0 || p.n == 0)
+isconst(p::Poly{T}) where {T<:Number} = p.n == 0
 
-function A_mul_B!{S<:Number,T<:Number,U<:Number,V<:Number}(alpha::Poly{S}, A::SparseMatrixCSC{T,Int}, x::Array{Poly{U},1}, beta::Poly{V}, y::Array{Poly{V},1})
+function mul!(alpha::Poly{S}, A::SparseMatrixCSC{T,Int}, x::Array{Poly{U},1}, beta::Poly{V}, y::Array{Poly{V},1}) where {S<:Number,T<:Number,U<:Number,V<:Number}
 
     @inbounds begin
     for i=1:length(y)
@@ -195,10 +200,11 @@ function A_mul_B!{S<:Number,T<:Number,U<:Number,V<:Number}(alpha::Poly{S}, A::Sp
     y
 end
 
-transpose{T<:Number}(p::Poly{T}) = p
+transpose(p::Poly{T}) where {T<:Number} = p
+adjoint(p::Poly{T}) where {T<:Number} = p
 
 # promote polynomial to share the same Symbol basis
-function promote_poly{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T})
+function promote_poly(p1::Poly{S}, p2::Poly{T}) where {S<:Number,T<:Number}
     if (p1.syms == p2.syms) || (isconst(p1) && isconst(p2)) return (p1, p2) end
     
     if isconst(p1)  && ~isconst(p2)
@@ -210,7 +216,7 @@ function promote_poly{S<:Number,T<:Number}(p1::Poly{S}, p2::Poly{T})
     end
 end
 
-function evalpoly{T<:Number,S<:Number}(p::Poly{T}, x::AbstractArray{S})
+function evalpoly(p::Poly{T}, x::AbstractArray{S}) where {S<:Number,T<:Number}
     val = zero(S)
     for j=1:p.m
         val += p.c[j]*prod(vec(x) .^ vec(p.alpha[j,:]))
@@ -219,11 +225,11 @@ function evalpoly{T<:Number,S<:Number}(p::Poly{T}, x::AbstractArray{S})
 end
 
 # combine identical terms and remove zero terms
-function simplify{T<:Number}(p::Poly{T})
+function simplify(p::Poly{T}) where {T<:Number}
 
     # handle simple cases explicitly to speed function up
     if p.m == 1 && p.c[1] == zero(T)
-        return Poly{T}(p.syms, Array(Int, 0, p.n), Array(T, 0))
+        return Poly{T}(p.syms, Array{Int,2}(undef, 0, p.n), Array{T,1}(undef, 0))
     end
     
     if p.m <= 1 
@@ -235,11 +241,11 @@ function simplify{T<:Number}(p::Poly{T})
     
     c = 1:p.n
     rows = [ view(p.alpha,i,c) for i=1:p.m ]
-    perm = sortperm(rows, order=Base.Order.Lexicographic)
+    perm = sortperm(rows)
     y = p.alpha*rand(p.n)
             
-    first = Array(Int, p.m)
-    c = Array(T, p.m)
+    first = Array{Int,1}(undef, p.m)
+    c = Array{T,1}(undef, p.m)
     
     l = 1
     @inbounds begin
@@ -262,7 +268,7 @@ function simplify{T<:Number}(p::Poly{T})
     y
 end
 
-function truncate{T<:Number}(p::Poly{T}, threshold=1e-10)
+function truncate(p::Poly{T}, threshold=1e-10) where {T<:Number}
     lgt = 0
     labeled = falses(p.m)
     
@@ -275,8 +281,8 @@ function truncate{T<:Number}(p::Poly{T}, threshold=1e-10)
     end
 
     # the unlabeled terms form the reduced polynomial
-    alpha = Array(Int, lgt, p.n)
-    c = Array(T, lgt)
+    alpha = Array{Int,2}(undef, lgt, p.n)
+    c = Array{T,1}(undef, lgt)
     lgt = 1
     for k=1:p.m
         if ~labeled[k]
@@ -285,13 +291,26 @@ function truncate{T<:Number}(p::Poly{T}, threshold=1e-10)
             lgt += 1
         end
     end
-    perm = sortperm([ vec(alpha[i,1:p.n]) for i=1:size(alpha,1)], lt=lexless)
-    Poly(p.syms, alpha[perm,:], c[perm])
+    perm = sortperm([ vec(alpha[i,1:p.n]) for i=1:size(alpha,1)], lt=isless)
+    Poly{T}(p.syms, alpha[perm,:], c[perm])
 end
 
+
+function round(p::Poly{T}; sigdigits=5) where {T<:Number}
+    # the unlabeled terms form the reduced polynomial
+    alpha = Array{Int,2}(undef, p.m, p.n)
+    c = Array{T,1}(undef, p.m)
+    for k=1:p.m
+        alpha[k,:] = p.alpha[k,:]
+        c[k] = round(p.c[k],sigdigits=sigdigits)
+    end
+    Poly{T}(p.syms, alpha, c)
+end
+
+
 # ordering for polynomials
-function isless{T<:Number}(p1::Poly{T}, p2::Poly{T})
-    lexless(p1.alpha, p2.alpha)
+function isless(p1::Poly{T}, p2::Poly{T}) where {T<:Number}
+    isless(p1.alpha, p2.alpha)
 end
 
 # function ordermap{T<:Number}(p::Poly{T})
@@ -317,7 +336,7 @@ end
 #     Poly{T}(p.syms, p.alpha[perm,:], p.c[perm])
 # end
 
-function order{T<:Number}(p::Poly{T})
+function order(p::Poly{T}) where {T<:Number}
     c = 1:size(p.alpha,2)
     rows = [ view(p.alpha,i,c) for i=1:size(p.alpha,1) ]
     perm = sortperm(rows, order=Base.Order.Lexicographic)
@@ -325,5 +344,5 @@ function order{T<:Number}(p::Poly{T})
 end
 
 variables(syms::Symbols) = [Poly{Int}(syms, [zeros(Int,1,k-1) 1 zeros(Int,1,length(syms.names)-k)], [1]) for k=1:length(syms.names)]
-variables{T<:AbstractString}(syms::Vector{T}) = variables(Symbols(syms))
-variables{T<:AbstractString}(sym::T, n::Int) = variables([string(sym,i) for i=1:n])
+variables(syms::Vector{T}) where {T<:AbstractString}= variables(Symbols(syms))
+variables(sym::T, n::Int) where {T<:AbstractString} = variables([string(sym,i) for i=1:n])


### PR DESCRIPTION
I made these changes to make the code work with Julia 1.5, since I had difficulty installing older versions of Julia. They're not great, but I tested against the notebooks and made sure they worked and the results were the same or close enough.

This commit only contains changes in `src`. I also have the updates to the notebooks, but didn't want to commit them because (1) I never figured out how to make `using Polyopt` work and so I used `include("Polyopt.jl")` instead (2) changes to notebooks can't be diffed.

The exception is the chordal embeddings: I wasn't able to figure out how the old code with `cholfact()` worked and so couldn't update to the new `cholesky()` interface. Also there's a warning about not being able to import `Base.sub`, which I didn't know what that was supposed to do, so I wasn't able to fix that.

Possibly you'll want to keep both versions of the code, in case someone is still using the Julia 0.6 build?